### PR TITLE
Refresh org profile README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,4 @@
-# .github
+# Convergint public GitHub profile
+
+This repository contains the public GitHub organization profile for
+Convergint.

--- a/profile/README.md
+++ b/profile/README.md
@@ -2,9 +2,9 @@
 
 This is the official GitHub organization for Convergint.
 
-Convergint is a global, service-based systems integrator. To learn more about
-our company, our services, and the industries we support, start with the links
-below.
+Convergint is a global, service-based systems integrator. If you'd like to
+learn more about our company, our services, and the industries we support,
+start with the links below.
 
 ## Learn More
 

--- a/profile/README.md
+++ b/profile/README.md
@@ -1,50 +1,13 @@
-# Welcome to Convergint's GitHub
+# Convergint
 
-Welcome to the official GitHub organization for Convergint! We're excited to have you here. This is the central hub for all our open-source projects, collaborations, and community-driven initiatives.
+This is the official GitHub organization for Convergint.
 
----
+Convergint is a global, service-based systems integrator. To learn more about
+our company, our services, and the industries we support, start with the links
+below.
 
-## Who We Are
+## Learn More
 
-Convergint is a technology organization that delivers solutions for customers around security and internally to accelerate and enable.
-
----
-
-## How to Get Started
-
-1. **Explore Our Repositories:**
-   - Browse through the [repositories](https://github.com/orgs/convergint/repositories) to discover projects that interest you.
-
-2. **Contribute to Projects:**
-   - Check out our [contributing guidelines](CONTRIBUTING.md) for detailed instructions on how to contribute.
-
-3. **Join the Community:**
-   - Follow us on [social media links] to stay updated.
-   - Join discussions in our [forums/Slack/Discord].
-
-4. **Report Issues or Suggest Features:**
-   - Use the "Issues" tab in the relevant repository to report bugs or suggest enhancements.
-
----
-
-## Code of Conduct
-
-We are committed to fostering an open and welcoming environment. Please read and adhere to our [Code of Conduct](CODE_OF_CONDUCT.md).
-
----
-
-## Contact Us
-
-For any questions or feedback, feel free to reach out via:
-- Email: [email@organization.com](mailto:email@organization.com)
-- Social Media: [Twitter/Facebook/LinkedIn links]
-
----
-
-## License
-
-Unless otherwise specified, all projects within this organization are licensed under the [MIT License](LICENSE).
-
----
-
-Happy coding! We're looking forward to seeing what we can build together. 🚀
+- Company website: https://www.convergint.com/
+- Who We Are: https://www.convergint.com/who-we-are/
+- Careers: https://www.convergint.com/careers/


### PR DESCRIPTION
Why?
====

The public organization profile was still placeholder text from a generic open-source template. That copy implied a community workflow we do not run here and pointed readers at missing contact and contribution paths. We want the public page to stay simple and company-facing, with just enough context to tell visitors who Convergint is and where to learn more.

How?
====

- Read the existing profile and compared it against the current role of the public org page.
- Rewrote the page around company-facing links and removed the generic GitHub-community copy.
- Verified the final company, who-we-are, and careers URLs before keeping the page intentionally sparse.

Demo
====

View the OLD rendered version: https://github.com/convergint/.github/blob/13aac11a199b6c5e381d1148dc8a09c50a9366dd/profile/README.md

View the NEW rendered version: https://github.com/convergint/.github/blob/0e392e56f6eb7716b3f70c1383b67e505d60ffb0/profile/README.md

----

[Related to EE-856](https://linear.app/convergint/issue/EE-856).
